### PR TITLE
Match key names to correspond with filename

### DIFF
--- a/metrics/bleurt/bleurt.py
+++ b/metrics/bleurt/bleurt.py
@@ -69,10 +69,10 @@ CHECKPOINT_URLS = {
     "bleurt-base-512": "https://storage.googleapis.com/bleurt-oss/bleurt-base-512.zip",
     "bleurt-large-128": "https://storage.googleapis.com/bleurt-oss/bleurt-large-128.zip",
     "bleurt-large-512": "https://storage.googleapis.com/bleurt-oss/bleurt-large-512.zip",
-    "bleurt-20-d3": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D3.zip",
-    "bleurt-20-d6": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D6.zip",
-    "bleurt-20-d12": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D12.zip",
-    "bleurt-20": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20.zip",
+    "BLEURT-20-D3": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D3.zip",
+    "BLEURT-20-D6": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D6.zip",
+    "BLEURT-20-D12": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20-D12.zip",
+    "BLEURT-20": "https://storage.googleapis.com/bleurt-oss-21/BLEURT-20.zip",
 }
 
 


### PR DESCRIPTION
In order to properly locate downloaded ckpt files key name needs to match filename